### PR TITLE
Adds protocol support to make-domain-requester

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,6 @@ install:
 
 script:
   - raco test -c request
+  - raco test --submodule integration-test request
   - raco doc-coverage request
   - if [ -n "$RUN_COVER" ]; then raco cover -f coveralls -d $TRAVIS_BUILD_DIR/coverage -c request; fi

--- a/request/private/http-location.rkt
+++ b/request/private/http-location.rkt
@@ -8,9 +8,11 @@
 (provide
  (contract-out
   [make-domain-requester
-   (->* (string? requester?) (#:protocol string?) requester?)]
+   (-> string? requester? requester?)]
   [make-host+port-requester
-   (-> string? exact-nonnegative-integer? requester? requester?)]))
+   (-> string? exact-nonnegative-integer? requester? requester?)]
+  [make-https-requester
+   (-> string? requester? requester?)]))
 
 
 (define (domain+relative-path->http-url protocol domain relative-path)
@@ -19,9 +21,13 @@
 (define (host+port->domain host port)
   (format "~a:~a" host port))
 
-(define (make-domain-requester domain requester #:protocol [protocol "http"])
+(define (make-domain-requester domain requester)
   (wrap-requester-location
-   (domain+relative-path->http-url protocol domain _) requester))
+   (domain+relative-path->http-url "http" domain _) requester))
+
+(define (make-https-requester domain requester)
+  (wrap-requester-location
+   (domain+relative-path->http-url "https" domain _) requester))
 
 (define (make-host+port-requester host port requester)
   (make-domain-requester (host+port->domain host port) requester))
@@ -37,7 +43,7 @@
 
   (define http-req (make-domain-requester domain http-requester))
   (define https-req
-    (make-domain-requester domain http-requester #:protocol "https"))
+    (make-https-requester domain http-requester))
  
   (define http-resp (get http-req "/ip"))
   (define https-resp (get https-req "/ip"))

--- a/request/private/http-location.rkt
+++ b/request/private/http-location.rkt
@@ -7,18 +7,45 @@
 
 (provide
  (contract-out
-  [make-domain-requester (-> string? requester? requester?)]
-  [make-host+port-requester (-> string? exact-nonnegative-integer? requester? requester?)]))
+  [make-domain-requester
+   (->* (string? requester?) (#:protocol string?) requester?)]
+  [make-host+port-requester
+   (-> string? exact-nonnegative-integer? requester? requester?)]))
 
 
-(define (domain+relative-path->http-url domain relative-path)
-  (string->url (format "http://~a/~a" domain relative-path)))
+(define (domain+relative-path->http-url protocol domain relative-path)
+  (string->url (format "~a://~a/~a" protocol domain relative-path)))
 
 (define (host+port->domain host port)
   (format "~a:~a" host port))
 
-(define (make-domain-requester domain requester)
-  (wrap-requester-location (domain+relative-path->http-url domain _) requester))
+(define (make-domain-requester domain requester #:protocol [protocol "http"])
+  (wrap-requester-location
+   (domain+relative-path->http-url protocol domain _) requester))
 
 (define (make-host+port-requester host port requester)
   (make-domain-requester (host+port->domain host port) requester))
+
+(module+ test
+  (require rackunit
+           "base.rkt"
+           "call-response.rkt")
+
+  (define domain "httpbin.org")
+  (define http-url (domain+relative-path->http-url "http" domain "/"))
+  (define https-url (domain+relative-path->http-url "https" domain "/"))
+
+  (define http-req (make-domain-requester domain http-requester))
+  (define https-req
+    (make-domain-requester domain http-requester #:protocol "https"))
+ 
+  (define http-resp (get http-req "/ip"))
+  (define https-resp (get https-req "/ip"))
+  
+  (check-pred url? http-url)
+  (check-equal? "http" (url-scheme http-url))
+  (check-equal? "https" (url-scheme https-url))
+  
+  (check-pred requester? http-req)
+  (check-equal? 200 (http-response-code http-resp))
+  (check-equal? 200 (http-response-code https-resp)))

--- a/request/private/http-location.scrbl
+++ b/request/private/http-location.scrbl
@@ -24,10 +24,11 @@ relative paths as locations.
   @racket[domain] to construct a full http @racket[url],
   which is then passed to the underlying @racket[requester].
   The relative path should not begin with a slash.
-  @racketinput[
+  @racketblock[
     (define foo-com-requester
       (make-domain-requester "foo.com" http-requester))
-    (get foo-com-requester "some/sort/of/path") ;; request to http://foo.com/some/sort/of/path
+    (code:comment @#,elem{request to http://foo.com/some/sort/of/path})                                                    
+    (get foo-com-requester "some/sort/of/path")
 ]}
 
 @defproc[(make-host+port-requester [host string?]
@@ -39,3 +40,15 @@ relative paths as locations.
   @racket[(make-host+port-requester "foo.com" 8080 some-requester)]
   is equivalent to @racket[(make-domain-requester "foo.com:8080" some-requester)]
 }
+
+@defproc[(make-https-requester [requester requester?])
+         requester?]{
+ Given a requester that accepts @racket[url?]s
+ as locations, returns a requester that accepts a @racket[url] and converts
+ it to use an https scheme before being passed to the underlying @racket[requester].
+ @racketblock[
+   (define foo-https-requester
+     (make-domain-requester "foo.com" (make-https-requester http-requester)))
+ (code:comment @#,elem{request to https://foo.com/some/sort/of/path})                                                    
+ (get foo-https-requester "some/sort/of/path")
+ ]}


### PR DESCRIPTION
When setting up a domain-requester you can pass the optional `#:protocol` keyword to enable HTTPS URLs. The default remains HTTP. 

Example:

``` scheme
(make-domain-requester "httpbin.org" http-requester #:protocol "https")
```
