### PR TITLE
Travis script cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-langauge: c
+language: c
 sudo: false
 env:
   global:
@@ -6,14 +6,23 @@ env:
   matrix:
     - RACKET_VERSION=6.1.1
     - RACKET_VERSION=6.2
+    - RACKET_VERSION=6.2.1
+    - RACKET_VERSION=6.3
+    - RACKET_VERSION=6.4
+    - RACKET_VERSION=6.5 RUN_COVER=true
+    - RACKET_VERSION=6.6
+    - RACKET_VERSION=HEAD
 
 before_install:
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket
   - cat ../travis-racket/install-racket.sh | bash
   - export PATH="${RACKET_DIR}/bin:${PATH}"
+  - raco pkg install --auto cover cover-coveralls doc-coverage
 
-install: raco pkg install --deps search-auto $TRAVIS_BUILD_DIR
+install:
+  - raco pkg install --auto $TRAVIS_BUILD_DIR
 
 script:
- - raco test $TRAVIS_BUILD_DIR
- - raco cover -f coveralls -d $TRAVIS_BUILD_DIR/coverage .
+  - raco test -c request
+  - raco doc-coverage request
+  - if [ -n "$RUN_COVER" ]; then raco cover -f coveralls -d $TRAVIS_BUILD_DIR/coverage -c request; fi

--- a/info.rkt
+++ b/info.rkt
@@ -1,11 +1,8 @@
 #lang info
 
-
 (define collection 'multi)
 
-
 (define version "0.1")
-
 
 (define deps
   '("base"
@@ -15,15 +12,11 @@
     "typed-racket-lib"
     "typed-racket-more"))
 
-
 (define build-deps
   '("net-doc"
-    "cover"
     "rackunit-lib"
     "rackunit-doc"
-    "racket-doc"
-    "doc-coverage"))
-
+    "racket-doc"))
 
 (define test-omit-paths
   '("info.rkt"

--- a/request/info.rkt
+++ b/request/info.rkt
@@ -1,6 +1,5 @@
 #lang info
 
-
 (define name "request")
 
 (define scribblings '(("main.scrbl" () (library) "request")))

--- a/request/tests/doc-coverage.rkt
+++ b/request/tests/doc-coverage.rkt
@@ -1,7 +1,0 @@
-#lang racket
-
-(module+ test
-  (require doc-coverage
-           request)
-  
-  (check-all-documented 'request))


### PR DESCRIPTION
- Use a RUN_COVER env var
- Remove extra whitespace in info files
- Test on more racket versions
- Add cover-coveralls installation
- Use doc-cover in travis only
