### PR TITLE
JSON Requester

### DIFF
--- a/request/main.rkt
+++ b/request/main.rkt
@@ -7,7 +7,8 @@
   "private/exn.rkt"
   "private/http-location.rkt"
   "private/call-response.rkt"
-  "private/wrap.rkt")
+  "private/wrap.rkt"
+  "private/json.rkt")
 
 
 (provide

--- a/request/main.rkt
+++ b/request/main.rkt
@@ -17,7 +17,8 @@
    "private/struct.rkt"
    "private/exn.rkt"
    "private/http-location.rkt"
-   "private/wrap.rkt")
+   "private/wrap.rkt"
+   "private/json.rkt")
   requester-get
   requester-put
   requester-post

--- a/request/private/base.rkt
+++ b/request/private/base.rkt
@@ -2,52 +2,25 @@
 
 (require net/url
          fancy-app
-         json
          "call-response.rkt"
          "struct.rkt")
 
-(provide http-requester
-         json-requester)
+(provide http-requester)
 
-(define json-headers
-  '("Accept: application/json" "Content-Type: application/json"))
+(define (http-get url #:headers [headers '()])
+  (call-response/input-url url (get-impure-port _ headers)))
 
-(define (merge-json-headers headers)
-  (flatten (cons json-headers headers)))
+(define (http-put url body #:headers [headers '()])
+  (call-response/input-url url (put-impure-port _ body headers)))
 
-(define (get call-response-fn url #:headers [headers '()])
-  (call-response-fn url (get-impure-port _ headers)))
+(define (http-post url body #:headers [headers '()])
+  (call-response/input-url url (post-impure-port _ body headers)))
 
-(define (put call-response-fn url body #:headers [headers '()])
-  (call-response-fn url (put-impure-port _ body headers)))
-
-(define (post call-response-fn url body #:headers [headers '()])
-  (call-response-fn url (post-impure-port _ body headers)))
-
-(define (delete call-response-fn url #:headers [headers '()])
-  (call-response-fn url (delete-impure-port _ headers)))
-
-(define (wrap-http-method method-fn)
-  (λ (url #:headers [headers '()] . rest)
-    (apply method-fn call-response/input-url url #:headers headers rest)))
-
-(define (wrap-json-method method-fn)
-  (λ (url #:headers [headers '()] . rest)
-    (apply method-fn call-response/input-json-url url #:headers
-           (merge-json-headers headers) rest)))
-
-(define (wrap-json-body method-fn)
-  (λ (url body #:headers [headers '()] . rest)
-    (apply method-fn url (jsexpr->bytes body) #:headers headers rest)))
+(define (http-delete url #:headers [headers '()])
+  (call-response/input-url url (delete-impure-port _ headers)))
 
 (define http-requester
-  (requester (wrap-http-method get)
-             (wrap-http-method put)
-             (wrap-http-method post)
-             (wrap-http-method delete)))
-
-(define json-requester
-  (requester (wrap-json-method get)
-             (wrap-json-body (wrap-json-method put))
-             (wrap-json-body (wrap-json-method post))
-             (wrap-json-method delete)))
+  (requester http-get
+             http-put
+             http-post
+             http-delete))

--- a/request/private/base.rkt
+++ b/request/private/base.rkt
@@ -2,11 +2,18 @@
 
 (require net/url
          fancy-app
+         json
          "call-response.rkt"
          "struct.rkt")
 
-(provide http-requester)
+(provide http-requester
+         json-requester)
 
+(define json-headers
+  '("Accept: application/json" "Content-Type: application/json"))
+
+(define (merge-headers headers)
+  (flatten (cons json-headers headers)))
 
 (define (http-get url #:headers [headers '()])
   (call-response/input-url url (get-impure-port _ headers)))
@@ -20,8 +27,37 @@
 (define (http-delete url #:headers [headers '()])
   (call-response/input-url url (delete-impure-port _ headers)))
 
+(define (http-json-get url #:headers [headers '()])
+  (call-response/input-json-url url (get-impure-port _ headers)))
+
+(define (http-json-put url body #:headers [headers '()])
+  (call-response/input-json-url url (put-impure-port _ body headers)))
+
+(define (http-json-post url body #:headers [headers '()])
+  (call-response/input-json-url url (post-impure-port _ body headers)))
+
+(define (http-json-delete url #:headers [headers '()])
+  (call-response/input-json-url url (delete-impure-port _ headers)))
+
+(define (wrap-json-headers method-fn)
+  (λ (url #:headers [headers '()] . rest)
+    (define json-headers (merge-headers headers))
+    (apply method-fn url #:headers json-headers rest)))
+
+(define (wrap-json-body method-fn)
+  (λ (url body #:headers [headers '()] . rest)
+    (define json-headers (merge-headers headers))
+    (define json-body (jsexpr->bytes body))
+    (apply method-fn url json-body #:headers json-headers rest)))
+
 (define http-requester
   (requester http-get
              http-put
              http-post
              http-delete))
+
+(define json-requester
+  (requester (wrap-json-headers http-json-get)
+             (wrap-json-body http-json-put)
+             (wrap-json-body http-json-post)
+             (wrap-json-headers http-json-delete)))

--- a/request/private/base.scrbl
+++ b/request/private/base.scrbl
@@ -31,28 +31,13 @@
 }
 
 @defrequester[json-requester]{
-  A simple requester for the HTTP protocol specifically for JSON requests
-  built with @racket[get-impure-port], @racket[put-impure-port],
-  @racket[post-impure-port], and @racket[delete-impure-port].
-  Locations are @racket[url?]s, headers are @racket[string?]s
-  as in the impure port functions, bodies are @racket[jsexpr?],
-  and responses are instances of the @racket[json-response] struct.
-  Two headers are automatically injected into the request:
-  "Content-Type: application/json" and "Accept: application/json".
-  The body of the request is automatically converted from a @racket[jsexpr?]
-  to a JSON string.
-}
-
-@defstruct*[json-response ([code exact-positive-integer?]
-                           [headers (hash/c string? string?
-                                            #:immutable? #t)]
-                           [body jsexpr?])]{
-  A structure type for HTTP JSON responses. Contains a status
-  code, a hash of headers, and a body @racket[jsexpr?].
-  @racket[json-requester] responds with instances of
-  this structure type. This is distinct from the
-  @racket[response] structure type in the web server
-  package, as that response is for @italic{sending}
-  responses while this struct is used when
-  @italic{receiving} them.
+  Wraps @racket[http-requester] and modifies the request to
+  include two headers: "Content-Type: application/json" and
+  "Accept: application/json". The body of the request is automatically converted
+  from a @racket[jsexpr?] to a JSON string. Locations are @racket[url?]s,
+  headers are @racket[string?]s as in the impure port functions, bodies are
+  @racket[jsexpr?], and responses are instances of the
+  @racket[json-response] struct. If the response comes back with non-JSON or it
+  cannot otherwise be parsed correctly into a @racket[jsexpr?] it will throw
+  @racket[exn:fail:json?]
 }

--- a/request/private/base.scrbl
+++ b/request/private/base.scrbl
@@ -36,8 +36,7 @@
   "Accept: application/json". The body of the request is automatically converted
   from a @racket[jsexpr?] to a JSON string. Locations are @racket[url?]s,
   headers are @racket[string?]s as in the impure port functions, bodies are
-  @racket[jsexpr?], and responses are instances of the
-  @racket[json-response] struct. If the response comes back with non-JSON or it
-  cannot otherwise be parsed correctly into a @racket[jsexpr?] it will throw
-  @racket[exn:fail:json?]
+  @racket[jsexpr?], and responses are instances of the @racket[json-response]
+  struct. If the response comes back with non-JSON or it cannot otherwise be
+  parsed correctly into a @racket[jsexpr?] it will throw @racket[exn:fail:json?]
 }

--- a/request/private/base.scrbl
+++ b/request/private/base.scrbl
@@ -29,3 +29,30 @@
   responses while this struct is used when
   @italic{receiving} them.
 }
+
+@defrequester[json-requester]{
+  A simple requester for the HTTP protocol specifically for JSON requests
+  built with @racket[get-impure-port], @racket[put-impure-port],
+  @racket[post-impure-port], and @racket[delete-impure-port].
+  Locations are @racket[url?]s, headers are @racket[string?]s
+  as in the impure port functions, bodies are @racket[jsexpr?],
+  and responses are instances of the @racket[json-response] struct.
+  Two headers are automatically injected into the request:
+  "Content-Type: application/json" and "Accept: application/json".
+  The body of the request is automatically converted from a @racket[jsexpr?]
+  to a JSON string.
+}
+
+@defstruct*[json-response ([code exact-positive-integer?]
+                           [headers (hash/c string? string?
+                                            #:immutable? #t)]
+                           [body jsexpr?])]{
+  A structure type for HTTP JSON responses. Contains a status
+  code, a hash of headers, and a body @racket[jsexpr?].
+  @racket[json-requester] responds with instances of
+  this structure type. This is distinct from the
+  @racket[response] structure type in the web server
+  package, as that response is for @italic{sending}
+  responses while this struct is used when
+  @italic{receiving} them.
+}

--- a/request/private/call-response.rkt
+++ b/request/private/call-response.rkt
@@ -6,6 +6,7 @@
          typed/json)
 
 (provide (struct-out http-response)
+         (struct-out json-response)
          HttpResponse
          Url
          call-response/input-url

--- a/request/private/call-response.rkt
+++ b/request/private/call-response.rkt
@@ -2,12 +2,14 @@
 
 (require typed/net/url
          typed/net/head
-         fancy-app)
+         fancy-app
+         typed/json)
 
 (provide (struct-out http-response)
          HttpResponse
          Url
-         call-response/input-url)
+         call-response/input-url
+         call-response/input-json-url)
 
 
 (struct http-response
@@ -15,7 +17,13 @@
    [headers : (HashTable String String)]
    [body : String]) #:transparent)
 
+(struct json-response
+  ([code : Positive-Integer]
+   [headers : (HashTable String String)]
+   [body : JSExpr]) #:transparent)
+
 (define-type HttpResponse http-response)
+(define-type JsonResponse json-response)
 (define-type Url url)
 
 (: not-newline? (-> Char Boolean))
@@ -41,17 +49,36 @@
   (define code-chars (takef dropped-protocol not-whitespace?))
   (cast (string->number (apply string code-chars)) Positive-Integer))
 
-(: impure-port->response (-> Input-Port HttpResponse))
-(define (impure-port->response impure-port)
+(: impure-port->headers
+   (-> Input-Port (Values Positive-Integer (HashTable String String))))
+(define (impure-port->headers impure-port)
   (define HTTP-header+MIME-headers (purify-port impure-port))
   (define-values (HTTP-header MIME-headers)
     (split-combined-header HTTP-header+MIME-headers))
   (define status-code (http-header-code HTTP-header))
-  (define headers (cast (make-hash (extract-all-fields MIME-headers)) (HashTable String String)))
+  (define headers
+    (cast (make-hash (extract-all-fields MIME-headers))
+          (HashTable String String)))
+  (values status-code headers))
+
+(: impure-port->http-response (-> Input-Port HttpResponse))
+(define (impure-port->http-response impure-port)
+  (define-values (status-code headers)
+    (impure-port->headers impure-port))
   (define raw-body (port->string impure-port))
   (http-response status-code headers raw-body))
 
+(: impure-port->json-response (-> Input-Port JsonResponse))
+(define (impure-port->json-response impure-port)
+  (define-values (status-code headers)
+    (impure-port->headers impure-port))
+  (define json-body (string->jsexpr (port->string impure-port)))
+  (json-response status-code headers json-body))
 
 (: call-response/input-url (-> Url (-> Url Input-Port) HttpResponse))
 (define (call-response/input-url url connect)
-  (call/input-url url connect impure-port->response))
+  (call/input-url url connect impure-port->http-response))
+
+(: call-response/input-json-url (-> Url (-> Url Input-Port) JsonResponse))
+(define (call-response/input-json-url url connect)
+  (call/input-url url connect impure-port->json-response))

--- a/request/private/call-response.rkt
+++ b/request/private/call-response.rkt
@@ -6,11 +6,9 @@
          typed/json)
 
 (provide (struct-out http-response)
-         (struct-out json-response)
          HttpResponse
          Url
-         call-response/input-url
-         call-response/input-json-url)
+         call-response/input-url)
 
 
 (struct http-response
@@ -18,13 +16,7 @@
    [headers : (HashTable String String)]
    [body : String]) #:transparent)
 
-(struct json-response
-  ([code : Positive-Integer]
-   [headers : (HashTable String String)]
-   [body : JSExpr]) #:transparent)
-
 (define-type HttpResponse http-response)
-(define-type JsonResponse json-response)
 (define-type Url url)
 
 (: not-newline? (-> Char Boolean))
@@ -34,7 +26,6 @@
 (: not-whitespace? (-> Char Boolean))
 (define (not-whitespace? char)
   (not (char-whitespace? char)))
-
 (: split-combined-header (-> String (Values String String)))
 (define (split-combined-header HTTP-header+MIME-headers)
   (define chars (string->list HTTP-header+MIME-headers))
@@ -50,36 +41,16 @@
   (define code-chars (takef dropped-protocol not-whitespace?))
   (cast (string->number (apply string code-chars)) Positive-Integer))
 
-(: impure-port->headers
-   (-> Input-Port (Values Positive-Integer (HashTable String String))))
-(define (impure-port->headers impure-port)
+(: impure-port->response (-> Input-Port HttpResponse))
+(define (impure-port->response impure-port)
   (define HTTP-header+MIME-headers (purify-port impure-port))
   (define-values (HTTP-header MIME-headers)
     (split-combined-header HTTP-header+MIME-headers))
   (define status-code (http-header-code HTTP-header))
-  (define headers
-    (cast (make-hash (extract-all-fields MIME-headers))
-          (HashTable String String)))
-  (values status-code headers))
-
-(: impure-port->http-response (-> Input-Port HttpResponse))
-(define (impure-port->http-response impure-port)
-  (define-values (status-code headers)
-    (impure-port->headers impure-port))
+  (define headers (cast (make-hash (extract-all-fields MIME-headers)) (HashTable String String)))
   (define raw-body (port->string impure-port))
   (http-response status-code headers raw-body))
 
-(: impure-port->json-response (-> Input-Port JsonResponse))
-(define (impure-port->json-response impure-port)
-  (define-values (status-code headers)
-    (impure-port->headers impure-port))
-  (define json-body (string->jsexpr (port->string impure-port)))
-  (json-response status-code headers json-body))
-
 (: call-response/input-url (-> Url (-> Url Input-Port) HttpResponse))
 (define (call-response/input-url url connect)
-  (call/input-url url connect impure-port->http-response))
-
-(: call-response/input-json-url (-> Url (-> Url Input-Port) JsonResponse))
-(define (call-response/input-json-url url connect)
-  (call/input-url url connect impure-port->json-response))
+  (call/input-url url connect impure-port->response))

--- a/request/private/call-response.rkt
+++ b/request/private/call-response.rkt
@@ -2,8 +2,7 @@
 
 (require typed/net/url
          typed/net/head
-         fancy-app
-         typed/json)
+         fancy-app)
 
 (provide (struct-out http-response)
          HttpResponse

--- a/request/private/exn.rkt
+++ b/request/private/exn.rkt
@@ -11,7 +11,6 @@
          http-requester/exn
          http-exn-of-code?)
 
-
 (define message-codes
   (hash 400 "Bad Request"
         401 "Unauthorized"

--- a/request/private/exn.scrbl
+++ b/request/private/exn.scrbl
@@ -15,6 +15,13 @@
   wrapped by @racket[requester-http-exn].
 }
 
+@defstruct*[(exn:fail:json exn:fail)
+            ([response string?])]{
+  This exception is thrown by @racket[json-requester]s
+  when they cannot parse the response as valid JSON. The original response
+  is returned as a string in the body of the exception.
+}
+
 @defproc[(requester-http-exn [requester requester?])
          requester?]{
   Given a @racket[requester] whose responses are @racket[http-response]s,

--- a/request/private/http-location.rkt
+++ b/request/private/http-location.rkt
@@ -29,8 +29,8 @@
    (domain+relative-path->http-url domain _) requester))
 
 (define (make-https-requester requester)
- (wrap-requester-location
-  (http-url->https-url _) requester))
+  (wrap-requester-location
+   (http-url->https-url _) requester))
 
 (define (make-host+port-requester host port requester)
   (make-domain-requester (host+port->domain host port) requester))
@@ -40,22 +40,76 @@
            rackunit
            "base.rkt"
            "call-response.rkt")
-
+  
   (define domain "httpbin.org")
   (define http-url (domain+relative-path->http-url domain "/"))
   (define http-req (make-domain-requester domain http-requester))
   (define https-req (make-domain-requester
                      domain (make-https-requester http-requester)))
- 
+  
+  (check-pred requester? http-req)
+  (check-pred requester? https-req)
+  
+  (define http-json-req (make-domain-requester domain json-requester))
+  (define https-json-req (make-domain-requester
+                          domain (make-https-requester json-requester)))
+  
+  (check-pred requester? http-json-req)
+  (check-pred requester? https-json-req)
+  
   (define http-resp (get http-req "/get"))
   (define https-resp (get https-req "/get"))
-
+  
   (check-pred url? http-url)
   (check-equal? (url-scheme http-url) "http")
   (check-equal?
    (hash-ref (string->jsexpr (http-response-body https-resp)) 'url)
    "https://httpbin.org/get")
   
-  (check-pred requester? http-req)
   (check-equal? (http-response-code http-resp) 200)
-  (check-equal? (http-response-code https-resp) 200))
+  (check-equal? (http-response-code https-resp) 200)
+  
+  (define http-json-get-resp
+    (get http-json-req "/get"
+         #:headers
+         '("Content-Type: application/json; charset=utf8"
+           "x-racket: yes")))
+  
+  (define http-json-post-resp
+    (post http-json-req "/post" (hasheq 'grand "larceny")))
+  (define https-json-get-resp (get https-json-req "/get"))
+  
+  (check-pred jsexpr? (json-response-body http-json-get-resp))
+  (check-pred jsexpr? (json-response-body https-json-get-resp))
+  
+  ; exception thrown for non-jsexpr body
+  (check-exn
+   exn:fail?
+   (λ ()
+     (post http-json-req "/post" 'felony)))
+  
+  (check-equal? (hash-ref
+                 (hash-ref
+                  (json-response-body http-json-get-resp)
+                  'headers)
+                 'Content-Type)
+                "application/json; charset=utf8")
+  
+  (check-equal? (hash-ref
+                 (hash-ref
+                  (json-response-body http-json-get-resp)
+                  'headers)
+                 'Accept)
+                "application/json")
+  
+  (check-equal? (hash-ref
+                 (hash-ref
+                  (json-response-body http-json-get-resp)
+                  'headers)
+                 'X-Racket)
+                "yes")
+  
+  (check-equal? (hash-ref
+                 (json-response-body http-json-post-resp)
+                 'data)
+                "{\"grand\":\"larceny\"}"))

--- a/request/private/http-location.rkt
+++ b/request/private/http-location.rkt
@@ -2,6 +2,7 @@
 
 (require net/url
          fancy-app
+         "json.rkt"
          "struct.rkt"
          "wrap.rkt")
 
@@ -50,13 +51,6 @@
   (check-pred requester? http-req)
   (check-pred requester? https-req)
   
-  (define http-json-req (make-domain-requester domain json-requester))
-  (define https-json-req (make-domain-requester
-                          domain (make-https-requester json-requester)))
-  
-  (check-pred requester? http-json-req)
-  (check-pred requester? https-json-req)
-  
   (define http-resp (get http-req "/get"))
   (define https-resp (get https-req "/get"))
   
@@ -67,49 +61,4 @@
    "https://httpbin.org/get")
   
   (check-equal? (http-response-code http-resp) 200)
-  (check-equal? (http-response-code https-resp) 200)
-  
-  (define http-json-get-resp
-    (get http-json-req "/get"
-         #:headers
-         '("Content-Type: application/json; charset=utf8"
-           "x-racket: yes")))
-  
-  (define http-json-post-resp
-    (post http-json-req "/post" (hasheq 'grand "larceny")))
-  (define https-json-get-resp (get https-json-req "/get"))
-  
-  (check-pred jsexpr? (json-response-body http-json-get-resp))
-  (check-pred jsexpr? (json-response-body https-json-get-resp))
-  
-  ; exception thrown for non-jsexpr body
-  (check-exn
-   exn:fail?
-   (λ ()
-     (post http-json-req "/post" 'felony)))
-  
-  (check-equal? (hash-ref
-                 (hash-ref
-                  (json-response-body http-json-get-resp)
-                  'headers)
-                 'Content-Type)
-                "application/json; charset=utf8")
-  
-  (check-equal? (hash-ref
-                 (hash-ref
-                  (json-response-body http-json-get-resp)
-                  'headers)
-                 'Accept)
-                "application/json")
-  
-  (check-equal? (hash-ref
-                 (hash-ref
-                  (json-response-body http-json-get-resp)
-                  'headers)
-                 'X-Racket)
-                "yes")
-  
-  (check-equal? (hash-ref
-                 (json-response-body http-json-post-resp)
-                 'data)
-                "{\"grand\":\"larceny\"}"))
+  (check-equal? (http-response-code https-resp) 200))

--- a/request/private/json.rkt
+++ b/request/private/json.rkt
@@ -25,7 +25,7 @@
     (add-requester-headers
      json-headers http-requester/exn))))
 
-(module+ test
+(module+ integration-test
   (require net/url
            rackunit)
 

--- a/request/private/json.rkt
+++ b/request/private/json.rkt
@@ -38,7 +38,7 @@
     (add-requester-headers
      json-headers http-requester/exn))))
 
-(module+ test
+(module+ integraton-test
   (require net/url
            rackunit)
 

--- a/request/private/json.rkt
+++ b/request/private/json.rkt
@@ -1,0 +1,76 @@
+#lang racket
+
+(require json
+         "base.rkt"
+         "exn.rkt"
+         "struct.rkt"
+         "wrap.rkt")
+
+(define json-headers
+  '("Accept: application/json" "Content-Type: application/json"))
+
+(define (wrap-json-body body)
+  (if (jsexpr? body)
+      (jsexpr->bytes body)
+      body))
+
+(define (handle-json-response response)
+  (string->jsexpr response))
+
+(define json-requester
+  (wrap-requester-response
+   handle-json-response
+   (wrap-requester-body
+    wrap-json-body
+    (add-requester-headers
+     json-headers http-requester/exn))))
+
+(module+ test
+  (require net/url
+           rackunit)
+
+  (check-pred requester? json-requester)
+
+  (define (make-url path)
+    (string->url (format "http://httpbin.org/~a" path)))
+
+  (define (get-headers response)
+    (hash-ref response 'headers))
+
+  (define (get-data response)
+    (hash-ref response 'data))
+  
+  (define json-get (requester-get json-requester))
+  (define json-put (requester-put json-requester))
+  (define json-post (requester-post json-requester))
+  (define json-delete (requester-delete json-requester))
+
+  (define get-200 ((requester-get json-requester)
+                   (make-url "get") #:headers '("x-men: colossus")))
+  (check-pred jsexpr? get-200)
+  (check-equal? (hash-ref (get-headers get-200) 'Content-Type)
+               "application/json")
+  (check-equal? (hash-ref (get-headers get-200) 'Accept)
+               "application/json")
+  (check-equal? (hash-ref (get-headers get-200) 'X-Men)
+                "colossus")
+
+  (define put-200 (json-put (make-url "put") (hash 'foo "bar")))
+  (check-pred jsexpr? put-200)
+  (check-equal? (get-data put-200) "{\"foo\":\"bar\"}")
+
+  (define post-200 (json-post (make-url "post") (hash 'foo "bar")))
+  (check-pred jsexpr? post-200)
+  (check-equal? (get-data post-200) "{\"foo\":\"bar\"}")
+
+  (define delete-200 (json-delete (make-url "delete")))
+  (check-pred jsexpr? delete-200)
+
+  ;; httpbin returns a non-JSON body for 418 Teapot
+  (check-exn
+   exn:fail:network:http:code?
+   (λ () (json-get (make-url "status/418"))))
+
+  (check-exn
+   exn:fail:network:http:code?
+   (λ () (json-get (make-url "status/406")))))


### PR DESCRIPTION
Fixes #12 
- Provides `json-requester`
- `json-requester` returns `json-response` struct
- When making requests with a `json-requester` the following headers are automatically injected: `Accept: application/json` and `Content-Type: application/json`. These can be overridden as normal.
- When making requests with a `json-requester` the `body` needs to be a valid `jsexpr?` and will be automatically converted to a bytes representation of a JSON string (ex: `(hasheq 'grand "larceny")` -> `"{\"grand\": \"larceny\"}"`)
- `json-response` expects the response body to be a valid `jsexpr?`
