### PR TITLE
fix delete method in documentation

### DIFF
--- a/request/private/struct.scrbl
+++ b/request/private/struct.scrbl
@@ -90,7 +90,6 @@
 
 @defproc[(delete [requester requester?]
                  [location any/c]
-                 [body any/c]
                  [#:headers headers list? '()])
          any/c]{
   Performs a DELETE request for the resource at @racket[location]


### PR DESCRIPTION
The `delete` method doesn't have a body parameter [in the code](https://github.com/jackfirth/racket-request/blob/master/request/private/base.rkt), updated the scribble file accordingly.